### PR TITLE
chore: add npm init default fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,20 @@
   },
   "engines": {
     "node": ">=8.16.2"
-  }
+  },
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
+  "directories": {
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/recursivefunk/good-env.git"
+  },
+  "bugs": {
+    "url": "https://github.com/recursivefunk/good-env/issues"
+  },
+  "homepage": "https://github.com/recursivefunk/good-env#readme"
 }


### PR DESCRIPTION
By adding the `repository` field, a user can use the npm cli to go to the repo with `npm repo good-env`. Also, it makes it easier for people who want to contribute to find the repo! 😄 

The `homepage` allows users to run `npm docs good-env` and be take to the README.

`bugs` allow users to go to the GitHub issues page using `npm bugs` or `npm issues`.

`directories` isn't too useful right now, but it [may be in the future](https://docs.npmjs.com/files/package.json#directories)

In addition, we specify the `files` property to ensure the bundle includes only the required files -- keep bundle size low, don't accidentally bundle untracked files. win-win