### PR TITLE
Fix small correctness bugs in getters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-env",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "description": "Better environment variable handling for Twelve-Factor node apps",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,7 @@ const isNumber = x => is(x) === '[object Number]';
 const isBoolean = x => is(x) === '[object Boolean]';
 const isObject = x => is(x) === '[object Object]';
 const isFunction = x => is(x) === '[object Function]';
-const parse = (items, converter) => items.map(t => converter(t, 10));
-const mapNums = items => parse(items, parseInt);
+const mapNums = items => items.map(t => parseFloat(t));
 const validType = item => ['number', 'boolean', 'string'].includes(item);
 const store = { ...process.env };
 
@@ -110,11 +109,7 @@ module.exports = Object
      * @returns {object}
      */
     getUrl (key, defaultVal) {
-      let urlStr = this.get(key, defaultVal);
-
-      if (urlStr === defaultVal) {
-        urlStr = defaultVal;
-      }
+      const urlStr = this.get(key, defaultVal);
 
       try {
         return makeGoodUrl({ url: new URL(urlStr) });
@@ -161,7 +156,7 @@ module.exports = Object
         return false;
       });
 
-      if (!ok(value) && typeof ok(defaultVal)) {
+      if (!ok(value) && ok(defaultVal)) {
         value = defaultVal;
       }
 
@@ -185,7 +180,7 @@ module.exports = Object
         }, {})
       );
 
-      const arrMapper = (keys, getter) => items.map(key => getter(key));
+      const arrMapper = (keys, getter) => keys.map(key => getter(key));
 
       if (isArray(items)) {
         return arrMapper(items, this.get);


### PR DESCRIPTION
## Summary

Four small, non-breaking correctness fixes in `src/index.js` surfaced while reading the code. Each is an existing bug that happens to be inert in current test paths. Bumps patch to 7.6.3.

## Changed Files

- `src/index.js` — four getter fixes:
  - `getUrl`: removed a no-op `if (urlStr === defaultVal) { urlStr = defaultVal }` block.
  - `get`: `typeof ok(defaultVal)` always produced the truthy string `'boolean'`, so falsy defaults (`null`, `0`, `''`) were being substituted for missing values. Now uses `ok(defaultVal)` directly.
  - `getAll`: `arrMapper` declared a `keys` parameter but closed over the outer `items`. Now uses the parameter as intended.
  - `mapNums`: switched from `parseInt` to `parseFloat` so list casting matches `getNumber` (which moved to float in 994d343). The unused `parse` helper was removed.
- `package.json` — version 7.6.2 → 7.6.3.

## Steps to Verify

- [ ] `npm test` — all 98 tests pass, 100% line coverage holds.
- [ ] `getUrl('X', 'https://example.com')` with `X` unset still returns the default URL object.
- [ ] `get('X', null)` with `X` unset returns `undefined` (previously returned `null`).
- [ ] `getList('NUMS', { cast: 'number' })` where `NUMS='1.5,2.5'` now returns `[1.5, 2.5]` instead of `[1, 2]`.
- [ ] `getAll(['A', 'B'])` still returns values in order.