### PR TITLE
Cover AWS_REGION default branch in use()

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,26 @@ test('it uses secrets manager (happy path)', async (t) => {
   t.end();
 });
 
+test('use() defaults region to us-east-1 when AWS_REGION is unset', async (t) => {
+  let capturedRegion;
+  class SpyClient {
+    constructor ({ region }) { capturedRegion = region; }
+    send () {
+      return Promise.resolve({ SecretString: JSON.stringify({ spyVal: 'x' }) });
+    }
+  }
+  const awsSecretsManager = { SecretsManagerClient: SpyClient, GetSecretValueCommand };
+  const saved = process.env.AWS_REGION;
+  delete process.env.AWS_REGION;
+  try {
+    await env.use(awsSecretsManager, 'my-secret');
+    t.equals(capturedRegion, 'us-east-1');
+  } finally {
+    process.env.AWS_REGION = saved;
+  }
+  t.end();
+});
+
 test('it gets an IP address', (t) => {
   const ip = env.getIP('VALID_IP');
   t.equals(ip, '192.168.1.60');


### PR DESCRIPTION
## Summary

Closes the last remaining uncovered branch in `src/index.js`: the `|| 'us-east-1'` fallback in `use()` when `process.env.AWS_REGION` is unset. Test-only change — no library behavior changes, no version bump.

## Changed Files

- `test/test.js` — new test `use() defaults region to us-east-1 when AWS_REGION is unset`. Uses a local spy `SecretsManagerClient` whose constructor captures `region`, then deletes `process.env.AWS_REGION` before calling `env.use()` and restores it in a `finally` block so subsequent tests (which rely on `AWS_REGION`) still pass.

## Steps to Verify

- [ ] `npm run ci` — all 131 tests pass.
- [ ] The coverage report shows `Uncovered Line #s` empty and branch coverage at 100% for `src/index.js` (was 98.95% with line 50 flagged).